### PR TITLE
chore(ci): improve overall GH Actions deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,26 +2,47 @@ name: Deploy
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  deploy:
-    name: Deploy
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install mdbook
-        uses: extractions/setup-crate@v1
+        uses: taiki-e/install-action@v2
         with:
-          owner: rust-lang
-          name: mdBook
-          version: "0.4.21"
-      - name: Clean output folder
+          tool: mdbook@0.4.36
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      - name: Clean book
         run: mdbook clean
       - name: Build book
         run: mdbook build
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: book
-          force_orphan: false
+          path: book/
+  deploy:
+    name: Deploy
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Change up a few things in the deployment process through GitHub actions as follows:

- Remove unmaintained actions with popular and active ones.
- Move over to official GitHub-managed actions where possible.
- Move to the new deployment natively done through GH Actions.

@togglebyte for this to work, a setting must be changed in the repo itself. Under the Pages deployment section, the method needs to be switched from the current `gh-pages` branch based variant to the GitHub Actions deployment method.
