### PR TITLE
updated outdated parts of the information

### DIFF
--- a/src/backend.md
+++ b/src/backend.md
@@ -22,8 +22,3 @@ when the runtime ends.
 ### `hide_cursor`
 
 Hides the cursor.
-
-### Quit on Ctrl-c
-
-This is enabled by default on the TUI backend.
-To disable this set `backend.quit_on_ctrl_c = false`.

--- a/src/runtime.md
+++ b/src/runtime.md
@@ -106,21 +106,6 @@ Default: `true`
 
 Returning a `bool` will enable/disable tabbing.
 
-### `ctrl_c`
-
-```rust,ignore
-fn ctrl_c(
-    &mut self,
-    event: Event,
-    elements: &mut Elements<'_, '_>,
-    global_context: &mut GlobalContext<'_>
-) -> Option<Event> { }
-```
-
-Default: `Some(event)`
-
-Returning `Some(event)` from this will cause the event to stop propagating and close down the runtime.
-
 ### `handle`
 
 ```rust,ignore


### PR DESCRIPTION
- removed `backend.quit_on_ctrl_c` as that got moved to the event handler.
- removed no-longer-existing function `ctrl_c` on the event handler

todo:
- reflect changes to the state (such as the removal of external state in favor of attributes)
> I wanted to wait with this in because of the large state rework that is currently being done, which may invalidate large parts of the documentation