### PR TITLE
"on_init" -> "on_mount"

### DIFF
--- a/src/components/events.md
+++ b/src/components/events.md
@@ -8,7 +8,7 @@ implementing one or more of the following methods:
 Event called when a component is added to the tree.
 
 ```rust,ignore
-fn on_init(
+fn on_mount(
     &mut self,
     state: &mut Self::State,
     mut children: Children<'_, '_>,


### PR DESCRIPTION
function definition typo